### PR TITLE
updated budget tree css

### DIFF
--- a/_src/fy2016-okc-budget-tree.jade
+++ b/_src/fy2016-okc-budget-tree.jade
@@ -49,7 +49,18 @@
     
     .children rect.parent {
       fill: #bbb;
-      fill-opacity: .5;
+      fill-opacity: 1;
+      -webkit-transition: fill-opacity .5s;
+      transition: fill-opacity .5s;
+    }
+
+    .children:hover{
+      cursor: pointer;
+    }
+
+    .children:hover rect.parent {
+      fill: #bbb;
+      fill-opacity: .85;
     }
     
     .children:hover rect.child {


### PR DESCRIPTION
updated budget tree css so that the child visualizations do not overtake the parent. I raised the opacity for .children rect.parent, from .5 to 1. To still allow for highlighting the elements underneath the parent, I added  hover styles and transitions that lower the opacity down to .85, which I think is still high enough to prevent the 'overlap' that's been discussed