### PR TITLE
issue: 91 right align the budget-tree-map and sort it alphabetically

### DIFF
--- a/_src/fy2016-okc-budget-tree.jade
+++ b/_src/fy2016-okc-budget-tree.jade
@@ -68,15 +68,22 @@
     }
 
     table.treemap {
-      width: 980px;
+      width: 1140px;
+      margin-left:-15px;
+      margin-top:30px;
     }
-
+  
+    table.treemap tr {
+      min-width:98%;
+    }
     table.treemap th {
       border-bottom:2pt solid rgb(221, 221, 221);
+      text-align:right;
     }
 
     table.treemap tr td {
       border-top:1pt solid rgb(221, 221, 221);
+      text-align:right;
     }
 
     table.treemap th, td {
@@ -214,7 +221,7 @@ script.
   
     function display(d) {
       $('table.treemap tbody').html('')
-      d.values.sort(function(a, b) { return a.value < b.value }).forEach(function(value) {
+      d.values.sort(function(a, b) { return a.key.toUpperCase().localeCompare(b.key.toUpperCase())}).forEach(function(value) {
         $('table.treemap tbody').append("<tr><td>" + value.key + "</td><td>$" + formatNumber(value.value) + "</td></tr>")
       });
 

--- a/_src/fy2016-okc-budget-tree.jade
+++ b/_src/fy2016-okc-budget-tree.jade
@@ -69,6 +69,7 @@
 
     table.treemap {
       width: 89vw;
+      max-width:1140px;
       margin-left:-15px;
       margin-top:30px;
     }

--- a/_src/fy2016-okc-budget-tree.jade
+++ b/_src/fy2016-okc-budget-tree.jade
@@ -68,7 +68,7 @@
     }
 
     table.treemap {
-      width: 1140px;
+      width: 89vw;
       margin-left:-15px;
       margin-top:30px;
     }


### PR DESCRIPTION
Changed the CSS to right align the table header and table data cells. Added some margin for readability, expanded the table for visual consistency when right aligned.

Changed the sort on the data from being the expense column greatest to least amount, to alphabetically via the item column.

resolve #91