### PR TITLE
fix whitespace around links

### DIFF
--- a/_src/_who-we-are.jade
+++ b/_src/_who-we-are.jade
@@ -2,12 +2,10 @@ div
   h2.subheader Who we are
   p
   | Open Budget: OKC is a project by #[a(href='http://codeforokc.org') Code for OKC] and is the result of many contributors including coders, community advocates, and city officials. We're looking for ideas and help, so get in touch and join in at our monthly
-  | meetups.  We have a monthly in-person meeting (please check
-  a(href='http://www.meetup.com/Code-for-OKC/' target='_blank') Meetup.com
-  |for location and time)
-  | and an online virtual meeting on the 2nd Wednesday of each month on our
-  a(href='http://slack.codeforokc.org' target='_blank') Code for OKC Slack
-  |.
+  | meetups.  We have a monthly in-person meeting (please check  
+  a(href='http://www.meetup.com/Code-for-OKC/' target='_blank') Meetup.com for location and time) 
+  | and an online virtual meeting on the 2nd Wednesday of each month on our 
+  a(href='http://slack.codeforokc.org' target='_blank') Code for OKC Slack.
   h4.subheader Current team:
   ul.list-unstyled
     li Scott Maslar (#[a(href='https://twitter.com/scottmaslar') twitter]/#[a(href='https://github.com/mascott') github])


### PR DESCRIPTION
For some reasons there ws some missing whitespace around the links on the who_we_are side.
They are trailing line spaces, and so invisible, before and after "Meetup.com" and before "Code for OKC Slack".